### PR TITLE
Open Graph Protocol implementation for embeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.org
+preview/

--- a/template.html
+++ b/template.html
@@ -4,6 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }} - {{ nick }}</title>
+        <!-- Open Graph Protocol -->
+        <meta property="og:title" content="{{ title }} - {{ nick }}">
+        <meta property="og:description" content="{{ content | og_description }}">
+        <meta property="og:type" content="article">
+        <meta property="og:url" content="{{ post_url }}">
+        <meta property="og:image" content="{{ avatar_url }}">
+        <meta property="og:site_name" content="Org Social Previews">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;


### PR DESCRIPTION
A preview tool wouldn't feel complete without an embed system, for interacting with other social media properly.
This is a sensible integration of the [OGP](https://ogp.me/) protocol, which has been widely adapted as the go-to embed framework. It's also fairly easy to implement with current structure.

Embeds now work properly (according to [an online tool](https://opengraph.dev/panel?url=https%3A%2F%2Fadsan.dev%2Fstatic%2Fpreview%2F2025-08-16T16-51-54plus0200.html)). The image-url is currently set as the user's avatar with no fallback - perhaps in a future iteration there could be a fallback to something post-related, org-social logo or something customizable by the user.